### PR TITLE
add priority value to second email address field (for WC3.5+)

### DIFF
--- a/classes/class-woocommerce-email-validation.php
+++ b/classes/class-woocommerce-email-validation.php
@@ -47,6 +47,9 @@ class WooCommerce_Email_Validation {
 					'class' 			=> apply_filters( 'woocommerce_confirm_email_field_class', array( 'form-row-last' ) ),
 					'clear'				=> true,
 					'validate'			=> array( 'email' ),
+					
+					// add priority value to second email address field (for WC 3.5+) 
+					'priority'			=> isset($return_fields['billing_email']['priority']) ? $return_fields['billing_email']['priority'] + 10 : 0,
 				);
 			}
 

--- a/classes/class-woocommerce-email-validation.php
+++ b/classes/class-woocommerce-email-validation.php
@@ -49,7 +49,7 @@ class WooCommerce_Email_Validation {
 					'validate'			=> array( 'email' ),
 					
 					// add priority value to second email address field (for WC 3.5+) 
-					'priority'			=> isset($return_fields['billing_email']['priority']) ? $return_fields['billing_email']['priority'] + 10 : 0,
+					'priority'			=> isset($return_fields['billing_email']['priority']) ? $return_fields['billing_email']['priority'] + 1 : 0,
 				);
 			}
 


### PR DESCRIPTION
Hi,

I created a commit to add "priority" to second email address field for Woocommerce 3.5+ .
Please check and merge it.
Thank you so much.

---

**Issue**
I'm using your plugin and Woocommerce on my website.
But, after updated Woocommerce to the latest version (3.5.1), 
second email address field was displayed as the first field in billing form.

![Screenshot](https://mrkr.io/s/5bf8cf0d78e14f3c2eccee02/0)

When I checked source code of Woocommerce 3.5.1, 
they added a sort method to sort billing fields by "priority".

https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-checkout.php#L243

```php
		foreach ( $this->fields as $field_type => $fields ) {
			// Sort each of the checkout field sections based on priority.
			uasort( $this->fields[ $field_type ], 'wc_checkout_fields_uasort_comparison' );
		}
```

**Resolve**
Add priority value to second email address field.

That's all.